### PR TITLE
fix rsync dry run

### DIFF
--- a/src/Plum/Deployer/RsyncDeployer.php
+++ b/src/Plum/Deployer/RsyncDeployer.php
@@ -46,7 +46,7 @@ class RsyncDeployer extends AbstractDeployer
         $login = sprintf('%s@%s:%s', $server->getUser(), $server->getHost(), $server->getDir());
 
         $command = sprintf('rsync %s %s %s ./ %s  %s',
-                $dryRun,
+                $dryRun ? "--dry-run" : "",
                 $rsyncOptions,
                 $ssh,
                 $login,


### PR DESCRIPTION
With dry_run turned on, rsync was called with '1' (true) value instead
of --dry-run param, which essentially bypassed dry_run and performed an
actual sync instead.
